### PR TITLE
Fix heroku app

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,7 +1,7 @@
 {
 	"comment": "",
 	"heroku": {
-		"goVersion": "go1.8",
+		"goVersion": "go1.8.7",
 		"install": [
 			"willnorris.com/go/gomfweb"
 		]

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,7 +3,7 @@
 	"heroku": {
 		"goVersion": "go1.8",
 		"install": [
-			"willnorris.com/go/microformats/cmd/gomfweb"
+			"willnorris.com/go/gomfweb"
 		]
 	},
 	"ignore": "",


### PR DESCRIPTION
https://go.microformats.io no longer looks like the other https://microformats.io subdomain sites.

https://ruby.microformats.io etc